### PR TITLE
Feature #49

### DIFF
--- a/src/components/popup-dialog/PopupDialog.tsx
+++ b/src/components/popup-dialog/PopupDialog.tsx
@@ -7,7 +7,7 @@ import { PaperProps } from '@mui/material'
 
 import useBreakpoints from '~/hooks/use-breakpoints'
 import { styles } from '~/components/popup-dialog/PopupDialog.styles'
-
+import { useModalContext } from '~/context/modal-context'
 interface PopupDialogProps {
   content: React.ReactNode
   paperProps: PaperProps
@@ -22,9 +22,9 @@ const PopupDialog: FC<PopupDialogProps> = ({
   closeModalAfterDelay
 }) => {
   const { isMobile } = useBreakpoints()
-
   const handleMouseOver = () => timerId && clearTimeout(timerId)
   const handleMouseLeave = () => timerId && closeModalAfterDelay()
+  const { closeModalAction } = useModalContext()
 
   return (
     <Dialog
@@ -41,7 +41,7 @@ const PopupDialog: FC<PopupDialogProps> = ({
         onMouseOver={handleMouseOver}
         sx={styles.box}
       >
-        <IconButton sx={styles.icon}>
+        <IconButton onClick={() => closeModalAction()} sx={styles.icon}>
           <CloseIcon />
         </IconButton>
         <Box sx={styles.contentWraper}>{content}</Box>

--- a/src/context/modal-context.tsx
+++ b/src/context/modal-context.tsx
@@ -22,6 +22,7 @@ interface ModalProvideContext {
   ) => void
   closeModal: () => void
   closeModalAction: () => void
+  setCloseCallback: (callback: () => void) => void
 }
 
 interface ModalProviderProps {
@@ -73,8 +74,8 @@ const ModalProvider: FC<ModalProviderProps> = ({ children }) => {
   )
 
   const contextValue = useMemo(
-    () => ({ openModal, closeModal, closeModalAction }),
-    [closeModal, openModal, closeModalAction]
+    () => ({ openModal, closeModal, closeModalAction, setCloseCallback }),
+    [closeModal, openModal, closeModalAction, setCloseCallback]
   )
 
   return (

--- a/src/context/modal-context.tsx
+++ b/src/context/modal-context.tsx
@@ -15,8 +15,13 @@ interface Component {
 }
 
 interface ModalProvideContext {
-  openModal: (component: Component, delayToClose?: number) => void
+  openModal: (
+    component: Component,
+    delayToClose?: number,
+    closeCallbackProp?: () => void
+  ) => void
   closeModal: () => void
+  closeModalAction: () => void
 }
 
 interface ModalProviderProps {
@@ -31,12 +36,18 @@ const ModalProvider: FC<ModalProviderProps> = ({ children }) => {
   const [modal, setModal] = useState<React.ReactElement | null>(null)
   const [paperProps, setPaperProps] = useState<PaperProps>({})
   const [timer, setTimer] = useState<NodeJS.Timeout | null>(null)
+  const [closeCallback, setCloseCallback] = useState<(() => void) | null>(null)
 
   const closeModal = useCallback(() => {
     setModal(null)
     setPaperProps({})
     setTimer(null)
+    setCloseCallback(null)
   }, [setModal, setPaperProps, setTimer])
+
+  const closeModalAction = useCallback(() => {
+    closeCallback ? closeCallback() : closeModal()
+  }, [closeCallback, closeModal])
 
   const closeModalAfterDelay = useCallback(
     (delay?: number) => {
@@ -47,18 +58,23 @@ const ModalProvider: FC<ModalProviderProps> = ({ children }) => {
   )
 
   const openModal = useCallback(
-    ({ component, paperProps }: Component, delayToClose?: number) => {
+    (
+      { component, paperProps }: Component,
+      delayToClose?: number,
+      closeCallbackProp?: () => void
+    ) => {
       setModal(component)
 
       paperProps && setPaperProps(paperProps)
       delayToClose && closeModalAfterDelay(delayToClose)
+      closeCallbackProp && setCloseCallback(closeCallbackProp)
     },
-    [setModal, setPaperProps, closeModalAfterDelay]
+    [setModal, setPaperProps, closeModalAfterDelay, setCloseCallback]
   )
 
   const contextValue = useMemo(
-    () => ({ openModal, closeModal }),
-    [closeModal, openModal]
+    () => ({ openModal, closeModal, closeModalAction }),
+    [closeModal, openModal, closeModalAction]
   )
 
   return (

--- a/src/context/modal-context.tsx
+++ b/src/context/modal-context.tsx
@@ -12,14 +12,11 @@ import { PaperProps } from '@mui/material/Paper'
 interface Component {
   component: React.ReactElement
   paperProps?: PaperProps
+  closeCallbackProp?: () => void
 }
 
 interface ModalProvideContext {
-  openModal: (
-    component: Component,
-    delayToClose?: number,
-    closeCallbackProp?: () => void
-  ) => void
+  openModal: (component: Component, delayToClose?: number) => void
   closeModal: () => void
   closeModalAction: () => void
   setCloseCallback: (callback: () => void) => void
@@ -60,9 +57,8 @@ const ModalProvider: FC<ModalProviderProps> = ({ children }) => {
 
   const openModal = useCallback(
     (
-      { component, paperProps }: Component,
-      delayToClose?: number,
-      closeCallbackProp?: () => void
+      { component, paperProps, closeCallbackProp }: Component,
+      delayToClose?: number
     ) => {
       setModal(component)
 


### PR DESCRIPTION
Added functionality to add callback functions when the dialog is closed. If the callback function is not specified, the popup will be closed when the close button is pressed, otherwise the callback function will be executed.
Example of use
```tsx
const { openModal } = useModalContext();
//...
openModal({component: <MyPopup/>, closeCallbackProp: () => () => { console.log("Hello world!") } })
``` 
**closeCallBackProp must be function that will return callBack for close button.**