### PR TITLE
[General Info step] Implemented autocompletion of first & last names (use-step-initial-values hook)

### DIFF
--- a/src/components/user-steps-wrapper/UserStepsWrapper.tsx
+++ b/src/components/user-steps-wrapper/UserStepsWrapper.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react'
+import { FC, useEffect } from 'react'
 import { useAppDispatch } from '~/hooks/use-redux'
 import { markFirstLoginComplete } from '~/redux/reducer'
 import StepWrapper from '~/components/step-wrapper/StepWrapper'
@@ -12,34 +12,40 @@ import LanguageStep from '~/containers/tutor-home-page/language-step/LanguageSte
 
 import { tutorStepLabels } from '~/components/user-steps-wrapper/constants'
 import { student } from '~/constants'
+import useStepsInitialValues from '~/hooks/use-steps-initial-values'
+import Loader from '~/components/loader/Loader'
+import { Container } from '~/components/shared'
 
 interface UserStepsWrapperProps {
   userRole: string
 }
 
 const UserStepsWrapper: FC<UserStepsWrapperProps> = ({ userRole }) => {
-  const [isUserFetched, setIsUserFetched] = useState(false)
   const dispatch = useAppDispatch()
+  const { initialValues, isPending } = useStepsInitialValues()
 
   useEffect(() => {
     dispatch(markFirstLoginComplete())
   }, [dispatch])
 
   const childrenArr = [
-    <GeneralInfoStep
-      isUserFetched={isUserFetched}
-      key='1'
-      setIsUserFetched={setIsUserFetched}
-    />,
-    <SubjectsStep key='2' />,
-    <LanguageStep key='3' />,
-    <AddPhotoStep key='4' />
+    <GeneralInfoStep btnsBox={null} key='1' />,
+    <SubjectsStep btnsBox={null} key='2' />,
+    <LanguageStep btnsBox={null} key='3' />,
+    <AddPhotoStep btnsBox={null} key='4' />
   ]
 
   const stepLabels = userRole === student ? '' : tutorStepLabels
 
+  if (isPending)
+    return (
+      <Container>
+        <Loader pageLoad />
+      </Container>
+    )
+
   return (
-    <StepProvider>
+    <StepProvider stepsInitialValues={initialValues}>
       <StepWrapper steps={stepLabels}>{childrenArr}</StepWrapper>
     </StepProvider>
   )

--- a/src/constants/translations/en/error-messages.json
+++ b/src/constants/translations/en/error-messages.json
@@ -2,5 +2,6 @@
   "fileSize": "Maximum file size - {{size}}",
   "resultsNotFound": "Sorry, no results found",
   "tryAgainText": "We couldn’t find what you were searching for. Please try again or suggest a new {{name}} that you were looking for.",
-  "buttonRequest": "Request a new {{name}}"
+  "buttonRequest": "Request a new {{name}}",
+  "firstLastNamesNotRetrieved": "First and Last names were not retrieved. Please enter them again"
 }

--- a/src/containers/home-page/add-photo-step/AddPhotoStep.tsx
+++ b/src/containers/home-page/add-photo-step/AddPhotoStep.tsx
@@ -10,7 +10,7 @@ import useUpload from '~/hooks/use-upload'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import PhotoPreviewUploader from './photo-preview/PhotoPreviewUploader'
 
-const AddPhotoStep = ({ btnsBox }: { btnsBox: JSX.Element }) => {
+const AddPhotoStep = ({ btnsBox }: { btnsBox: JSX.Element | null }) => {
   const { t } = useTranslation()
   const {
     data: {

--- a/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.tsx
+++ b/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.tsx
@@ -32,7 +32,7 @@ const AutocompleteStyledTyped = AutocompleteStyled as <T>(
 ) => JSX.Element
 
 interface GeneralInfoStepProps {
-  btnsBox: JSX.Element
+  btnsBox: JSX.Element | null
 }
 
 const GeneralInfoStep: FC<GeneralInfoStepProps> = ({ btnsBox }) => {

--- a/src/context/step-context.tsx
+++ b/src/context/step-context.tsx
@@ -1,18 +1,23 @@
-import { createContext, ReactNode, useContext } from 'react'
+import { createContext, FC, ReactNode, useContext } from 'react'
 import { StepDataType } from '~/types/components/step-context/step-context.types'
 import useForm, { UseFormOutput } from '~/hooks/use-form'
-import {
-  stepDataInitialValues,
-  stepDataValidations
-} from '~/containers/tutor-home-page/constants'
+import { stepDataValidations } from '~/containers/tutor-home-page/constants'
 
 type CtxType = UseFormOutput<StepDataType>
 
 const StepContext = createContext<CtxType>({} as CtxType)
 
-const StepProvider = ({ children }: { children: ReactNode }) => {
+interface StepContextProps {
+  stepsInitialValues: StepDataType
+  children: ReactNode
+}
+
+const StepProvider: FC<StepContextProps> = ({
+  children,
+  stepsInitialValues
+}) => {
   const useStepForm = useForm<StepDataType>({
-    initialValues: stepDataInitialValues,
+    initialValues: stepsInitialValues,
     validations: stepDataValidations
   })
 

--- a/src/hooks/use-steps-initial-values.tsx
+++ b/src/hooks/use-steps-initial-values.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+import { stepDataInitialValues } from '~/containers/tutor-home-page/constants'
+import { userService } from '~/services/user-service'
+import { UserRoleEnum } from '~/types'
+import { useSnackBarContext } from '~/context/snackbar-context'
+import { useTranslation } from 'react-i18next'
+import { useAppSelector } from '~/hooks/use-redux'
+
+export const useStepsInitialValues = () => {
+  const [initialValues, setInitialValues] = useState(stepDataInitialValues)
+  const [isPending, setIsPending] = useState(true)
+  const { setAlert } = useSnackBarContext()
+  const { userId } = useAppSelector((state) => state.appMain)
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    userService
+      .getUserById(userId, UserRoleEnum.Tutor)
+      .then((user) => {
+        const { firstName, lastName } = user.data
+        setInitialValues((prevState) => ({
+          ...prevState,
+          firstName,
+          lastName
+        }))
+      })
+      .catch(() => {
+        setAlert({
+          severity: 'error',
+          message: t('errorMessages.firstLastNamesNotRetrieved')
+        })
+      })
+      .finally(() => {
+        setIsPending(false)
+      })
+  }, [setAlert, t, userId])
+
+  return { initialValues, isPending }
+}
+
+export default useStepsInitialValues


### PR DESCRIPTION
- `use-step-initial-values.tsx` hook added to manage request to backend for getting user data (first name, last name) and set it to step context initial values
- loader added:

<img width="1439" alt="Знімок екрана 2024-08-09 о 12 44 19" src="https://github.com/user-attachments/assets/fc32a1be-6efa-496e-8b12-a3e606505680">

- error added:
<img width="1280" alt="Знімок екрана 2024-08-09 о 12 57 54" src="https://github.com/user-attachments/assets/f535d6f7-9710-456f-8ef3-e967e42bfc74">

