### PR TITLE
[Bugfix] home router fixed

### DIFF
--- a/src/pages/logout/Logout.tsx
+++ b/src/pages/logout/Logout.tsx
@@ -10,7 +10,7 @@ const Logout = () => {
 
   const onLogoutUser = useCallback(async () => {
     await logoutUser()
-    navigate(guestRoutes.home.route)
+    navigate(guestRoutes.home.path)
   }, [logoutUser, navigate])
 
   useEffect(() => {

--- a/src/router/constants/guestRoutes.ts
+++ b/src/router/constants/guestRoutes.ts
@@ -1,12 +1,12 @@
 export const guestRoutes = {
   home: { route: '/', path: '/' },
   welcome: { route: 'welcome', path: '/#welcome' },
-  student: { route: 'student', path: 'student' },
-  tutor: { route: 'tutor', path: 'tutor' },
-  admin: { route: 'admin', path: 'admin' },
-  error: { route: 'error', path: 'error' },
-  about: { route: 'about', path: 'about' },
-  privacyPolicy: { route: 'privacy-policy', path: 'privacy-policy' },
+  student: { route: 'student', path: '/student' },
+  tutor: { route: 'tutor', path: '/tutor' },
+  admin: { route: 'admin', path: '/admin' },
+  error: { route: 'error', path: '/error' },
+  about: { route: 'about', path: '/about' },
+  privacyPolicy: { route: 'privacy-policy', path: '/privacy-policy' },
   termOfUse: { route: '#', path: '#' },
   navBar: {
     whatCanYouDo: { route: 'what-сan-you-do', path: '/#what-сan-you-do' },

--- a/src/router/helpers/HomeRoute.tsx
+++ b/src/router/helpers/HomeRoute.tsx
@@ -10,7 +10,7 @@ const HomeRoute = () => {
 
   useEffect(() => {
     if (userRole) {
-      navigate(guestRoutes[userRole].route)
+      navigate(guestRoutes[userRole].path)
     }
   }, [navigate, userRole])
 

--- a/src/tests/unit/router/helpers/HomeRoute.spec.jsx
+++ b/src/tests/unit/router/helpers/HomeRoute.spec.jsx
@@ -34,7 +34,7 @@ describe('HomeRoute component', () => {
       preloadedState: studentState
     })
 
-    expect(mockedUseNavigate).toHaveBeenCalledWith('student')
+    expect(mockedUseNavigate).toHaveBeenCalledWith('/student')
   })
 
   it('should navigate to "tutor" when userRole is corresponded', () => {
@@ -42,7 +42,7 @@ describe('HomeRoute component', () => {
       preloadedState: tutorState
     })
 
-    expect(mockedUseNavigate).toHaveBeenCalledWith('tutor')
+    expect(mockedUseNavigate).toHaveBeenCalledWith('/tutor')
   })
 
   it('should navigate to "admin" when userRole is corresponded', () => {
@@ -50,6 +50,6 @@ describe('HomeRoute component', () => {
       preloadedState: adminState
     })
 
-    expect(mockedUseNavigate).toHaveBeenCalledWith('admin')
+    expect(mockedUseNavigate).toHaveBeenCalledWith('/admin')
   })
 })


### PR DESCRIPTION
Now when we are logged in as a tutor, and we go to `/`, we will be navigated to `/tutor` home page as were expected